### PR TITLE
add 'check_model' function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-version = "0.0.1rc1"
+version = "0.0.1"
 dependencies = ["rashdf", "hydrostab", "fsspec", "rich", "networkx", "jsonschema"]
 
 [project.optional-dependencies]

--- a/rasqc/__init__.py
+++ b/rasqc/__init__.py
@@ -9,3 +9,21 @@ standards, particularly for FFRD (Federal Flood Risk Determination) models.
 from .registry import *
 from .checkers import *
 from .check import *
+
+from typing import List
+
+
+def check_model(ras_model: str, checksuite: str) -> List[RasqcResult]:
+    """Run a checksuite on a HEC-RAS model.
+
+    Parameters
+    ----------
+        ras_model: Path to the HEC-RAS model to check.
+        checksuite: The name of the checksuite to run.
+
+    Returns
+    -------
+        None
+    """
+    results = CHECKSUITES[checksuite].run_checks(ras_model)
+    return results

--- a/rasqc/checkers/stability.py
+++ b/rasqc/checkers/stability.py
@@ -16,6 +16,9 @@ STABILITY_VARS = [
     "Water Surface",
     "Flow",
 ]
+STABILITY_VARS_POINT = [
+    "Water Surface",
+]
 UNSTABLE_THRESHOLD = 0.002  # 0.002 is the default for hydrostab
 
 
@@ -128,7 +131,7 @@ class RefpointStability(RasqcChecker):
         filename = os.path.basename(phdf._loc)
         results = []
         for id, name in zip(refpoint_ids, refpoint_names):
-            for var in STABILITY_VARS:
+            for var in STABILITY_VARS_POINT:
                 da_is_stable = ds_refpoint_stability[f"{var} is Stable"]
                 da_score = ds_refpoint_stability[f"{var} Stability Score"]
                 is_stable = da_is_stable.sel(refpt_id=id).all()


### PR DESCRIPTION
* Add `rasqc.check_model` function for ease of use as a library
* Address bug with stability checks on reference point hydrographs
* Bump to 0.0.1 for release