### PR TITLE
Switch to from ffspec to obstore for text file ops

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+# Install AWS CLI
+RUN apt-get update && \
+    apt-get install -y curl unzip && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "rasqc-devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/python:1":{"version":"3.12"}
+	},
+  "mounts": [],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"charliermarsh.ruff",
+				"GitHub.copilot",
+				"amazonwebservices.aws-toolkit-vscode"
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/envs/rasqc/bin/python"
+			}
+		}
+	},
+	// avoid dubious ownership of the workspace folder https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+	"postCreateCommand": "sudo chown -R vscode:vscode ${containerWorkspaceFolder}"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,11 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/devcontainers/features/python:1":{"version":"3.12"}
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.12"
+		}
 	},
-  "mounts": [],
+	"mounts": [],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ python -m venv venv-rasqc
 $ source ./venv-rasqc/bin/activate
 ```
 ```
-(venv-rasqc) $ pip install -r requirements.txt
+(venv-rasqc) $ pip install ".[dev]"
 ```
 To run:
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-version = "0.0.1"
+version = "0.0.2"
 dependencies = ["rashdf", "hydrostab", "fsspec", "rich", "networkx", "jsonschema", "obstore==0.6.0"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 version = "0.0.1"
-dependencies = ["rashdf", "hydrostab", "fsspec", "rich", "networkx", "jsonschema"]
+dependencies = ["rashdf", "hydrostab", "fsspec", "rich", "networkx", "jsonschema", "obstore==0.6.0"]
 
 [project.optional-dependencies]
 dev = ["pre-commit", "ruff", "pytest", "pytest-cov"]

--- a/rasqc/checkers/hdfsync.py
+++ b/rasqc/checkers/hdfsync.py
@@ -152,14 +152,22 @@ class PlanHdfDatetime(RasqcChecker):
         "Plan HDF file datetime should be newer than the Geometry HDF file datetime."
     )
 
-    def _check(self, plan_file: PlanFile) -> RasqcResult:
+    def _check(self, ras_model: RasModel, plan_file: PlanFile) -> RasqcResult:
         """Check if the Plan HDF datetime aligns with the Geometry file datetime."""
-        geom_file = plan_file.geom_file
+        geom_file_ext = plan_file.geom_file_ext
+        geom_file = ras_model.geom_files.get(geom_file_ext)
+        if not geom_file:
+            return RasqcResult(
+                name=self.name,
+                filename=Path(plan_file.hdf_path).name,
+                result=ResultStatus.ERROR,
+                message=f"Geometry file '{geom_file_ext}' not found.",
+            )
         ghdf = geom_file.hdf
         if not ghdf:
             return RasqcResult(
                 name=self.name,
-                filename=Path(plan_file._hdf_path).name,
+                filename=Path(plan_file.hdf_path).name,
                 result=ResultStatus.ERROR,
                 message="Geometry HDF file not found.",
             )
@@ -170,7 +178,7 @@ class PlanHdfDatetime(RasqcChecker):
         if not phdf:
             return RasqcResult(
                 name=self.name,
-                filename=Path(plan_file._hdf_path).name,
+                filename=Path(plan_file.hdf_path).name,
                 result=ResultStatus.ERROR,
                 message="Plan HDF file not found.",
             )
@@ -183,18 +191,18 @@ class PlanHdfDatetime(RasqcChecker):
                 err_msg = f"'{plan_file.path.name}': {self.criteria} ({run_time_start} > {ghdf_datetime})"
                 return RasqcResult(
                     name=self.name,
-                    filename=Path(plan_file._hdf_path).name,
+                    filename=Path(plan_file.hdf_path).name,
                     result=ResultStatus.ERROR,
                     message=err_msg,
                 )
             return RasqcResult(
                 name=self.name,
-                filename=Path(plan_file._hdf_path).name,
+                filename=Path(plan_file.hdf_path).name,
                 result=ResultStatus.OK,
             )
         return RasqcResult(
             name=self.name,
-            filename=Path(plan_file._hdf_path).name,
+            filename=Path(plan_file.hdf_path).name,
             result=ResultStatus.ERROR,
             message="Run Time Window not found in HDF file.",
         )
@@ -210,4 +218,4 @@ class PlanHdfDatetime(RasqcChecker):
         -------
             RasqcResult: The result of the check.
         """
-        return [self._check(plan_file) for plan_file in ras_model.plans]
+        return [self._check(ras_model, plan_file) for plan_file in ras_model.plans]

--- a/rasqc/checkers/plan_settings.py
+++ b/rasqc/checkers/plan_settings.py
@@ -76,6 +76,6 @@ class EquationSet2D(RasqcChecker):
         results = []
         for plan in ras_model.plans:
             if plan.hdf:
-                phdf_filename = Path(plan._hdf_path).name
+                phdf_filename = Path(plan.hdf_path).name
                 results.extend(self._check(plan.hdf, phdf_filename))
         return results

--- a/rasqc/checkers/projection.py
+++ b/rasqc/checkers/projection.py
@@ -91,5 +91,5 @@ class GeomProjection(RasqcChecker):
         for geom_file in ras_model.geometries:
             ghdf = geom_file.hdf
             if ghdf:
-                results.append(self._check(ghdf, Path(geom_file._hdf_path).name))
+                results.append(self._check(ghdf, Path(geom_file.hdf_path).name))
         return results

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -333,8 +333,8 @@ class RasModel:
         -------
             GeomFile: The current geometry file.
         """
-        current_geom_ext = self.current_plan.geom_file.path.suffix
-        return self.geom_files[current_geom_ext[1:]]
+        current_geom_ext = self.current_plan.geom_file_ext
+        return self.geom_files[current_geom_ext]
 
     @property
     def current_unsteady(self) -> UnsteadyFlowFile:
@@ -344,8 +344,8 @@ class RasModel:
         -------
             UnsteadyFlowFile: The current unsteady flow file.
         """
-        current_unsteady_ext = self.current_plan.unsteady_flow_file.path.suffix
-        return self.unsteady_flow_files[current_unsteady_ext[1:]]
+        current_unsteady_ext = self.current_plan.flow_file_ext
+        return self.unsteady_flow_files[current_unsteady_ext]
 
     @property
     def geometries(self) -> list[GeomFile]:

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -81,7 +81,7 @@ class RasModelFile:
                 .readall()
                 .to_bytes()
                 .decode("utf-8")
-                .replace("\r\n", "\n") # normalize line endings
+                .replace("\r\n", "\n")  # normalize line endings
             )
 
     @property

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -100,16 +100,15 @@ class RasModelFile:
 def _obstore_protocol_url(
     store: obstore.store.ObjectStore, path: str | os.PathLike
 ) -> str:
-    config: dict = store.config
     match store:
         case obstore.store.S3Store():
-            bucket = config["bucket"]
+            bucket = store.config["bucket"]
             return "s3", f"s3://{bucket}/{store.prefix}/{path}"
         case obstore.store.GCSStore():
-            bucket = config["bucket"]
+            bucket = store.config["bucket"]
             return "gs", f"gs://{bucket}/{store.prefix}/{path}"
         case obstore.store.AzureStore():
-            container_name = config["container_name"]
+            container_name = store.config["container_name"]
             return "az", f"az://{container_name}/{store.prefix}/{path}"
         case obstore.store.HTTPStore():
             return "https", f"{store.url}/{path}"

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -155,7 +155,7 @@ class GeomFile(RasModelFile):
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
             self.hdf = RasGeomHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "blockcache"}
+                url, fsspec_kwargs={"default_cache_type": "first"}
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasGeomHdf(self.hdf_path)
@@ -214,7 +214,7 @@ class PlanFile(RasModelFile):
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
             self.hdf = RasPlanHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "blockcache"}
+                url, fsspec_kwargs={"default_cache_type": "first"}
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasPlanHdf(self.hdf_path)

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -156,7 +156,11 @@ class GeomFile(RasModelFile):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
             print(f"Opening HDF file: {url}")
             self.hdf = RasGeomHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "blockcache", "default_block_size": 10**5}
+                url,
+                fsspec_kwargs={
+                    "default_cache_type": "blockcache",
+                    "default_block_size": 10**5,
+                },
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasGeomHdf(self.hdf_path)
@@ -216,7 +220,11 @@ class PlanFile(RasModelFile):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
             print(f"Opening HDF file: {url}")
             self.hdf = RasPlanHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "blockcache", "default_block_size": 10**5}
+                url,
+                fsspec_kwargs={
+                    "default_cache_type": "blockcache",
+                    "default_block_size": 10**5,
+                },
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasPlanHdf(self.hdf_path)

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -1,25 +1,18 @@
 """HEC-RAS model file and model classes."""
 
-import fsspec
 import obstore
-from obstore.fsspec import FsspecStore
-from rashdf import RasHdf, RasGeomHdf, RasPlanHdf
+from rashdf import RasGeomHdf, RasPlanHdf
 
 from datetime import datetime
 import os
 from pathlib import Path
 import re
-from typing import List, Optional, TypedDict
+from typing import List, Optional
 
 
-def _get_fsspec_protocol(fs: fsspec.AbstractFileSystem) -> str:
-    """Get the protocol of the fsspec file system."""
-    if isinstance(fs.protocol, (list, tuple)):
-        return fs.protocol[0]
-    return fs.protocol
-
-
-def _obstore_file_exists(store: obstore.store.ObjectStore, path: str | os.PathLike) -> bool:
+def _obstore_file_exists(
+    store: obstore.store.ObjectStore, path: str | os.PathLike
+) -> bool:
     if path is None:
         return False
     try:
@@ -47,13 +40,11 @@ class RasModelFile:
     hdf_path: Path to the associated HDF file, if applicable.
     """
 
-    # fs: fsspec.AbstractFileSystem
     local: bool
     store: Optional[obstore.store.ObjectStore] = None
     hdf_path: Optional[Path] = None
 
     def __init__(
-        # self, path: str | os.PathLike, fs: Optional[fsspec.AbstractFileSystem] = None
         self, path: str | os.PathLike, store: Optional[obstore.store.ObjectStore] = None
     ):
         """Instantiate a RasModelFile object by the file path.
@@ -62,8 +53,8 @@ class RasModelFile:
         ----------
         path : str | os.Pathlike
             The absolute path to the RAS file.
-        fs : fsspec.AbstractFileSystem, optional
-            The fsspec file system object. If not provided, it will be created based on the path.
+        store : obstore.store.ObjectStore, optional
+            The obstore file system object. If not provided, it will be created based on the path.
         """
         # local file
         if not store and os.path.exists(path):
@@ -72,19 +63,24 @@ class RasModelFile:
             self.filename = os.path.basename(path)
             self.path = Path(path)
             self.hdf_path = _get_hdf_path(self.path)
-            # self.hdf_filename = os.path.basename(self.hdf_path) if self.hdf_path else None
             self.content = open(path, "r").read()
 
+        # remote file, with store provided
         elif store:
             self.local = False
             self.store = store
             self.filename = os.path.basename(path)
             self.path = Path(self.filename)
             self.hdf_path = _get_hdf_path(self.path)
-            # self.hdf_filename = os.path.basename(self.hdf_path) if self.hdf_path else None
-            self.content = obstore.open_reader(self.store, self.filename).readall().to_bytes().decode("utf-8").replace("\r\n", "\n")
-            print(f"loaded '{self.filename}' from {self.store}")
-        
+            self.content = (
+                obstore.open_reader(self.store, self.filename)
+                .readall()
+                .to_bytes()
+                .decode("utf-8")
+                .replace("\r\n", "\n")
+            )
+
+        # remote file
         else:
             self.local = False
             prefix = os.path.dirname(path)
@@ -92,28 +88,13 @@ class RasModelFile:
             self.filename = os.path.basename(path)
             self.path = Path(self.filename)
             self.hdf_path = _get_hdf_path(self.path)
-            # self.hdf_filename = os.path.basename(self.hdf_path) if self.hdf_path else None
-            self.content = obstore.open_reader(self.store, self.filename).readall().to_bytes().decode("utf-8").replace("\r\n", "\n")
-            print(f"loaded '{self.filename}' from {self.store}")
-        
-
-        # prefix = os.path.dirname(path)
-        # filename = os.path.basename(path)
-        # self.path = Path(self.filename)
-        # self.hdf_path = _get_hdf_path(self.path)
-        # if not store and os.path.exists(path):
-        #     self.store = None
-        #     self.content = open(path, "r").read()
-        # elif store:
-        #     self.store = store
-        #     self.content = obstore.open_reader(self.store, filename.strip()).readall().to_bytes().decode("utf-8").replace("\r\n", "\n")
-        # else:
-        #     self.store = obstore.store.from_url(prefix)
-        #     self.content = obstore.open_reader(self.store, filename.strip()).readall().to_bytes().decode("utf-8").replace("\r\n", "\n")
-
-        # print(self.hdf_path)
-        # print('RasModelFile.hdf_path', self.hdf_path)
-        # print('\n')
+            self.content = (
+                obstore.open_reader(self.store, self.filename)
+                .readall()
+                .to_bytes()
+                .decode("utf-8")
+                .replace("\r\n", "\n")
+            )
 
     @property
     def title(self):
@@ -126,15 +107,6 @@ class RasModelFile:
         match = re.search(r"(?m)^(Proj|Geom|Plan|Flow) Title\s*=\s*(.+)$", self.content)
         title = match.group(2)
         return title
-
-
-def _get_hdf(
-    path: str | os.PathLike, fs: fsspec.AbstractFileSystem
-) -> Optional[RasHdf]:
-    """Given a Plan or Geometry path, return the corresponding HDF object."""
-    hdf_path = f"{path}.hdf"
-    if fs.exists(hdf_path):
-        return RasHdf.open_uri(hdf_path)
 
 
 def _obstore_protocol_url(
@@ -168,7 +140,6 @@ class GeomFile(RasModelFile):
     hdf: Optional[RasGeomHdf] = None
 
     def __init__(
-        # self, path: str | os.PathLike, fs: Optional[fsspec.AbstractFileSystem] = None
         self, path: str | os.PathLike, store: Optional[obstore.store.ObjectStore] = None
     ):
         """Instantiate a GeomFile object by the file path.
@@ -177,27 +148,17 @@ class GeomFile(RasModelFile):
         ----------
         path : str | os.Pathlike
             The absolute path to the RAS geometry file.
-        fs : fsspec.AbstractFileSystem, optional
-            The fsspec file system object. If not provided, it will be created based on the path.
+        store : obstore.store.ObjectStore, optional
+            The obstore file system object. If not provided, it will be created based on the path.
         """
         super().__init__(path, store)
-        # if store and _obstore_file_exists(self.store, self.hdf_path):
-        #     protocol, url = _obstore_protocol_url(self.store, self.hdf_path)
-        #     fsspec_store = FsspecStore(protocol)
-        #     f = fsspec_store.open(url, "rb")
-        #     self.hdf = RasGeomHdf(f)
-        #     self.hdf._loc = self.hdf_path
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
-            self.hdf = RasGeomHdf.open_uri(url, fsspec_kwargs={"default_cache_type": "blockcache"})
-        elif self.hdf_path and os.path.exists(self.hdf_path):
-            self.hdf = RasGeomHdf.open_uri(self.hdf_path, fsspec_kwargs={"default_cache_type": "blockcache"})
-
-        # super().__init__(path, fs)
-        # protocol = _get_fsspec_protocol(self.fs)
-        # self._hdf_path = f"{protocol}://{self.path}.hdf"
-        # if self.fs.exists(self._hdf_path):
-            # self.hdf = RasGeomHdf.open_uri(self._hdf_path, fsspec_kwargs={"default_cache_type": "blockcache"})
+            self.hdf = RasGeomHdf.open_uri(
+                url, fsspec_kwargs={"default_cache_type": "blockcache"}
+            )
+        elif os.path.exists(self.hdf_path):
+            self.hdf = RasGeomHdf(self.hdf_path)
 
     def last_updated(self) -> datetime:
         """Get the last updated date of the file.
@@ -238,7 +199,6 @@ class PlanFile(RasModelFile):
     hdf: Optional[RasPlanHdf] = None
 
     def __init__(
-        # self, path: str | os.PathLike, fs: Optional[fsspec.AbstractFileSystem] = None
         self, path: str | os.PathLike, store: Optional[obstore.store.ObjectStore] = None
     ):
         """Instantiate a PlanFile object by the file path.
@@ -247,24 +207,17 @@ class PlanFile(RasModelFile):
         ----------
         path : str | os.Pathlike
             The absolute path to the RAS geometry file.
-        fs : fsspec.AbstractFileSystem, optional
-            The fsspec file system object. If not provided, it will be created based on the path.
+        store : obstore.store.ObjectStore, optional
+            The obstore file system object. If not provided, it will be created based on the path.
         """
         super().__init__(path, store)
-        # if store and _obstore_file_exists(self.store, self.hdf_path):
-        #     protocol, url = _obstore_protocol_url(self.store, self.hdf_path)
-        #     fsspec_store = FsspecStore(protocol)
-        #     f = fsspec_store.open(url, "rb")
-        #     self.hdf = RasPlanHdf(f)
-        #     self.hdf._loc = self.hdf_path
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
-            self.hdf = RasPlanHdf.open_uri(url, fsspec_kwargs={"default_cache_type": "blockcache"})
-        # super().__init__(path, fs)
-        # protocol = _get_fsspec_protocol(self.fs)
-        # self._hdf_path = f"{protocol}://{self.path}.hdf"
-        # if self.fs.exists(self._hdf_path):
-        #     self.hdf = RasPlanHdf.open_uri(self._hdf_path, fsspec_kwargs={"default_cache_type": "blockcache"})
+            self.hdf = RasPlanHdf.open_uri(
+                url, fsspec_kwargs={"default_cache_type": "blockcache"}
+            )
+        elif os.path.exists(self.hdf_path):
+            self.hdf = RasPlanHdf(self.hdf_path)
 
     @property
     def geom_file_ext(self) -> str:
@@ -277,9 +230,6 @@ class PlanFile(RasModelFile):
         match = re.search(r"(?m)Geom File\s*=\s*(.+)$", self.content)
         geom_ext = match.group(1)
         return geom_ext
-        # print('self.path', self.path)
-        # print('GeomFile', self.path.with_suffix(f".{geom_ext}"))
-        # return GeomFile(self.path.with_suffix(f".{geom_ext}"), self.store)
 
     @property
     def flow_file_ext(self) -> str:
@@ -292,7 +242,6 @@ class PlanFile(RasModelFile):
         match = re.search(r"(?m)Flow File\s*=\s*(.+)$", self.content)
         flow_ext = match.group(1)
         return flow_ext
-        # return UnsteadyFlowFile(self.path.with_suffix(f".{flow_ext}"), self.fs)
 
     @property
     def short_id(self) -> str:
@@ -336,30 +285,19 @@ class RasModel:
         self.unsteady_flow_files = {}
         self.plan_files = {}
 
-        # fs = self.prj_file.fs
-        
-        # print('self.prj_file.path', self.prj_file.path, self.prj_file.path.with_suffix('.hdf'), '\n')
-
         for suf in re.findall(r"(?m)Geom File\s*=\s*(.+)$", self.prj_file.content):
-            # print('suf', suf)
-            # print('self.prj_file.path.with_suffix', self.prj_file.path.with_suffix("." + suf))
-            # print(self.prj_file.path)
-            # print(self.prj_file.path.with_suffix("." + suf))
             self.geom_files[suf] = GeomFile(
                 self.prj_file.path.with_suffix("." + suf), self.prj_file.store
-                # self.prj_file.path.with_suffix("." + suf), fs
             )
 
         for suf in re.findall(r"(?m)Unsteady File\s*=\s*(.+)$", self.prj_file.content):
             self.unsteady_flow_files[suf] = UnsteadyFlowFile(
                 self.prj_file.path.with_suffix("." + suf), self.prj_file.store
-                # self.prj_file.path.with_suffix("." + suf), fs
             )
 
         for suf in re.findall(r"(?m)Plan File\s*=\s*(.+)$", self.prj_file.content):
             self.plan_files[suf] = PlanFile(
                 self.prj_file.path.with_suffix("." + suf), self.prj_file.store
-                # self.prj_file.path.with_suffix("." + suf), fs
             )
 
         current_plan_ext = re.search(

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -142,7 +142,6 @@ class GeomFile(RasModelFile):
         super().__init__(path, store)
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
-            print(f"Opening HDF file: {url}")
             self.hdf = RasGeomHdf.open_uri(
                 url,
                 fsspec_kwargs={
@@ -206,7 +205,6 @@ class PlanFile(RasModelFile):
         super().__init__(path, store)
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
-            print(f"Opening HDF file: {url}")
             self.hdf = RasPlanHdf.open_uri(
                 url,
                 fsspec_kwargs={

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -154,8 +154,9 @@ class GeomFile(RasModelFile):
         super().__init__(path, store)
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
+            print(f"Opening HDF file: {url}")
             self.hdf = RasGeomHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "first"}
+                url, fsspec_kwargs={"default_cache_type": "blockcache", "default_block_size": 10**5}
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasGeomHdf(self.hdf_path)
@@ -213,8 +214,9 @@ class PlanFile(RasModelFile):
         super().__init__(path, store)
         if store and _obstore_file_exists(self.store, self.hdf_path):
             _, url = _obstore_protocol_url(self.store, self.hdf_path)
+            print(f"Opening HDF file: {url}")
             self.hdf = RasPlanHdf.open_uri(
-                url, fsspec_kwargs={"default_cache_type": "first"}
+                url, fsspec_kwargs={"default_cache_type": "blockcache", "default_block_size": 10**5}
             )
         elif os.path.exists(self.hdf_path):
             self.hdf = RasPlanHdf(self.hdf_path)

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -65,26 +65,14 @@ class RasModelFile:
             self.hdf_path = _get_hdf_path(self.path)
             self.content = open(path, "r").read()
 
-        # remote file, with store provided
-        elif store:
-            self.local = False
-            self.store = store
-            self.filename = os.path.basename(path)
-            self.path = Path(self.filename)
-            self.hdf_path = _get_hdf_path(self.path)
-            self.content = (
-                obstore.open_reader(self.store, self.filename)
-                .readall()
-                .to_bytes()
-                .decode("utf-8")
-                .replace("\r\n", "\n")
-            )
-
         # remote file
         else:
             self.local = False
-            prefix = os.path.dirname(path)
-            self.store = obstore.store.from_url(prefix)
+            if store:
+                self.store = store
+            else:
+                prefix = os.path.dirname(path)
+                self.store = obstore.store.from_url(prefix)
             self.filename = os.path.basename(path)
             self.path = Path(self.filename)
             self.hdf_path = _get_hdf_path(self.path)
@@ -93,7 +81,7 @@ class RasModelFile:
                 .readall()
                 .to_bytes()
                 .decode("utf-8")
-                .replace("\r\n", "\n")
+                .replace("\r\n", "\n") # normalize line endings
             )
 
     @property

--- a/tests/test_rasmodel.py
+++ b/tests/test_rasmodel.py
@@ -7,7 +7,7 @@ BALDEAGLE_PRJ = TEST_DATA / "ras/BaldEagleDamBrk.prj"
 
 def test_RasModelFile():
     rmf = RasModelFile(BALDEAGLE_PRJ)
-    assert rmf.path == BALDEAGLE_PRJ.absolute()
+    assert rmf.path == BALDEAGLE_PRJ
     assert rmf.hdf_path == None
     assert rmf.title == "Bald Eagle Creek Example Dam Break Study"
 
@@ -19,30 +19,30 @@ def test_RasModel():
     print(rmf.current_plan)
     assert rmf.current_plan.path.suffix == ".p18"
     assert rmf.geometry_paths == [
-        BALDEAGLE_PRJ.with_suffix(".g06").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".g11").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".g06"),
+        BALDEAGLE_PRJ.with_suffix(".g11"),
     ]
     assert rmf.geometry_hdf_paths == [
-        BALDEAGLE_PRJ.with_suffix(".g06.hdf").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".g11.hdf").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".g06.hdf"),
+        BALDEAGLE_PRJ.with_suffix(".g11.hdf"),
     ]
     assert rmf.geometry_titles == ["Bald Eagle Multi 2D Areas", "2D to 2D Connection"]
     assert rmf.plan_paths == [
-        BALDEAGLE_PRJ.with_suffix(".p13").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".p18").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".p13"),
+        BALDEAGLE_PRJ.with_suffix(".p18"),
     ]
     assert rmf.plan_hdf_paths == [
-        BALDEAGLE_PRJ.with_suffix(".p13.hdf").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".p18.hdf").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".p13.hdf"),
+        BALDEAGLE_PRJ.with_suffix(".p18.hdf"),
     ]
     assert rmf.plan_titles == ["PMF with Multi 2D Areas", "2D to 2D Run"]
     assert rmf.unsteady_paths == [
-        BALDEAGLE_PRJ.with_suffix(".u07").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".u10").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".u07"),
+        BALDEAGLE_PRJ.with_suffix(".u10"),
     ]
     assert rmf.unsteady_hdf_paths == [
-        BALDEAGLE_PRJ.with_suffix(".u07.hdf").absolute(),
-        BALDEAGLE_PRJ.with_suffix(".u10.hdf").absolute(),
+        BALDEAGLE_PRJ.with_suffix(".u07.hdf"),
+        BALDEAGLE_PRJ.with_suffix(".u10.hdf"),
     ]
     assert rmf.unsteady_titles == [
         "PMF with Multi 2D Areas",


### PR DESCRIPTION
# Description
Performance improvements when reading from cloud object storage.
* Switches from `fsspec` to [obstore](https://github.com/developmentseed/obstore) for text file operations.
* It seems that fsspec is still better for partial HDF reads. Configures a more appropriate caching methdology for reading HDF files.
  * When the HDF file is read, data requests are made in 100KB blocks at minimum -- meaning that if only 5KB of data is needed, then a full 100KB block will be requested regardless, and the extra data will be cached to avoid subsequent requests. Under the hood, `h5py` is doing a lot of small, nearly-sequential reads, so caching data with a small-ish block size speeds things up a lot.
* When running on my laptop against a model on S3 (`s3://trinity-pilot/Checkpoint2-ModelsForBackCheck/Hydraulics/C-MillCrk/Model/Trinity_1203_C_MillCrk/C_MillCrk_1203_Upper_New.prj`), I see runtime drop from ~8+ minutes to ~15 seconds.

# Testing
`python -m rasqc.cli s3://trinity-pilot/Checkpoint2-ModelsForBackCheck/Hydraulics/C-MillCrk/Model/Trinity_1203_C_MillCrk/C_MillCrk_1203_Upper_New.prj`

(or, you can point to a local model, but obviously that won't test the performance improvements)