### PR TITLE
add alternative HEC-RAS datetime format and fix bug with bridge xs data check

### DIFF
--- a/rasqc/checkers/structures.py
+++ b/rasqc/checkers/structures.py
@@ -137,7 +137,7 @@ class BridgeXsData(RasqcChecker):
                         msg_dict.setdefault(bridge_name, set()).add(
                             "bridge XSs without manning's breaks at the banks"
                         )
-                    if mann_dict.get(xs["banks"][0]) > 0.06:
+                    elif mann_dict.get(xs["banks"][0]) > 0.06:
                         msg_dict.setdefault(bridge_name, set()).add(
                             "bridge XSs with elevated channel n value(s)"
                         )

--- a/rasqc/rasmodel.py
+++ b/rasqc/rasmodel.py
@@ -182,6 +182,12 @@ class GeomFile(RasModelFile):
             except ValueError:
                 pass
             try:
+                dt = datetime.strptime(m, "%b-%d-%Y %H:%M:%S")
+                datetimes.append(dt)
+                continue
+            except ValueError:
+                pass
+            try:
                 dt = datetime.strptime(m, "%d%b%Y %H:%M:%S")
                 datetimes.append(dt)
                 continue


### PR DESCRIPTION
This PR addresses the following items:

- adds an additional `datetime` format encountered within HEC-RAS HDF files
- fixes a bug within the `structures.BridgeXsData` check class that caused the tool to fail